### PR TITLE
Update the "go get" instruction to avoid error report [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ NATS Streaming provides the following high-level feature set:
 
 ```bash
 # Go client
-go get github.com/nats-io/stan.go
+go get github.com/nats-io/stan.go/
 ```
 
 ## Basic Usage


### PR DESCRIPTION
Doing "go get github.com/nats-io/stan.go" reports an error about
"no such file or directory" although things are downloaded ok.

However, doing "go get github.com/nats-io/stan.go/" (with the
trailing "/") works fine.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>