### PR TITLE
Add note on workaround for Go modules go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ NATS Streaming provides the following high-level feature set:
 go get github.com/nats-io/stan.go/
 ```
 
+When using or transitioning to Go modules support:
+
+```bash
+# Go client latest or explicit version
+go get github.com/nats-io/stan.go/@latest
+go get github.com/nats-io/stan.go/@v0.5.0
+```
+
 ## Basic Usage
 
 ```go


### PR DESCRIPTION
Similar to the one for the NATS Go client.