### PR TITLE
[IMPROVED] Added wrong cluster ID hint in connect timeout error

### DIFF
--- a/stan.go
+++ b/stan.go
@@ -99,7 +99,7 @@ const (
 
 // Errors
 var (
-	ErrConnectReqTimeout = errors.New("stan: connect request timeout")
+	ErrConnectReqTimeout = errors.New("stan: connect request timeout (possibly wrong cluster ID?)")
 	ErrCloseReqTimeout   = errors.New("stan: close request timeout")
 	ErrSubReqTimeout     = errors.New("stan: subscribe request timeout")
 	ErrUnsubReqTimeout   = errors.New("stan: unsubscribe request timeout")


### PR DESCRIPTION
When a client calls stan.Connect() with a cluster ID that is
different that the server's cluster ID, the request will timeout.
This is expected since the server does not receive the connect
request at all, so the client times out waiting for the reply.

We are adding a hint in the error message which may help some users:
`stan: connect request timeout (possibly wrong cluster ID?)`

Resolves #285

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>