### PR TITLE
[FIXED] Set internal NATS subscriptions limits to "unlimited"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,21 @@ sudo: false
 go:
 - 1.11.x
 - 1.12.x
+env:
+- GO111MODULE=off
 go_import_path: github.com/nats-io/stan.go
 install:
-- go get -t ./...
+- go get -t -v ./...
 - go get github.com/nats-io/nats-streaming-server
-- go get github.com/mattn/goveralls
-- go get github.com/wadey/gocovmerge
 - go get -u honnef.co/go/tools/cmd/staticcheck
 - go get -u github.com/client9/misspell/cmd/misspell
 before_script:
 - $(exit $(go fmt ./... | wc -l))
 - go vet ./...
-- misspell -error -locale US .
+- find . -type f -name "*.go" | grep -v "/pb/" | xargs misspell -error -locale US
 - staticcheck ./...
 script:
-- go test -i -race ./...
+- go test -i -v ./...
 - go test -v -race ./...
 after_success:
 - if [[ "$TRAVIS_GO_VERSION" =~ 1.12 ]]; then ./scripts/cov.sh TRAVIS; fi

--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -1,6 +1,11 @@
 #!/bin/bash -e
 # Run from directory above via ./scripts/cov.sh
 
+export GO111MODULE="off"
+
+go get github.com/mattn/goveralls
+go get github.com/wadey/gocovmerge
+
 rm -rf ./cov
 mkdir cov
 go test -v -covermode=atomic -coverprofile=./cov/stan.out

--- a/stan.go
+++ b/stan.go
@@ -410,7 +410,7 @@ func Connect(stanClusterID, clientID string, options ...Option) (Conn, error) {
 		c.Close()
 		return nil, err
 	}
-	c.ackSubscription.SetPendingLimits(1024*1024, 32*1024*1024)
+	c.ackSubscription.SetPendingLimits(-1, -1)
 	c.pubAckMap = make(map[string]*ack)
 
 	// Create Subscription map

--- a/stan_test.go
+++ b/stan_test.go
@@ -1730,11 +1730,12 @@ func TestSlowAsyncSubscriber(t *testing.T) {
 	})
 	// Make sure these are the defaults
 	pm, pb, _ := sub.PendingLimits()
-	if pm != nats.DefaultSubPendingMsgsLimit {
-		t.Fatalf("Pending limit for number of msgs incorrect, expected %d, got %d\n", nats.DefaultSubPendingMsgsLimit, pm)
+	unlimited := -1
+	if pm != unlimited {
+		t.Fatalf("Pending limit for number of msgs incorrect, expected %d, got %d\n", unlimited, pm)
 	}
-	if pb != nats.DefaultSubPendingBytesLimit {
-		t.Fatalf("Pending limit for number of bytes incorrect, expected %d, got %d\n", nats.DefaultSubPendingBytesLimit, pb)
+	if pb != unlimited {
+		t.Fatalf("Pending limit for number of bytes incorrect, expected %d, got %d\n", unlimited, pb)
 	}
 
 	// Set new limits

--- a/sub.go
+++ b/sub.go
@@ -257,6 +257,7 @@ func (sc *conn) subscribe(subject, qgroup string, cb MsgHandler, options ...Subs
 	if err != nil {
 		return nil, err
 	}
+	nsub.SetPendingLimits(-1, -1)
 	sub.inboxSub = nsub
 
 	// Create a subscription request


### PR DESCRIPTION
Obverved with a subscription with very high MaxInflight (100,000)
and server on different machine that subscription would miss
messages (gap in new messages sequence) which was tracked down
to the internal susbcription dropping messages when reaching
the 64K default pending limit.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>