### PR TITLE
Cleanup some code

### DIFF
--- a/stan.go
+++ b/stan.go
@@ -291,21 +291,27 @@ type conn struct {
 	subMap           map[string]*subscription
 	pubAckMap        map[string]*ack
 	pubAckChan       chan (struct{})
+	pubAckCloseChan  chan (struct{})
 	opts             Options
 	nc               *nats.Conn
 	ncOwned          bool       // NATS Streaming created the connection, so needs to close it.
 	pubNUID          *nuid.NUID // NUID generator for published messages.
 	connLostCB       ConnectionLostHandler
+	closed           bool
+	ping             pingInfo
+}
 
-	pingMu       sync.Mutex
-	pingSub      *nats.Subscription
-	pingTimer    *time.Timer
-	pingBytes    []byte
-	pingRequests string
-	pingInbox    string
-	pingInterval time.Duration
-	pingMaxOut   int
-	pingOut      int
+// Holds all field related to the client-to-server pings
+type pingInfo struct {
+	mu       sync.Mutex
+	sub      *nats.Subscription
+	timer    *time.Timer
+	proto    []byte
+	requests string
+	inbox    string
+	interval time.Duration
+	maxOut   int
+	out      int
 }
 
 // Closure for ack contexts.
@@ -319,7 +325,15 @@ type ack struct {
 // Note that clientID can contain only alphanumeric and `-` or `_` characters.
 func Connect(stanClusterID, clientID string, options ...Option) (Conn, error) {
 	// Process Options
-	c := conn{clientID: clientID, opts: DefaultOptions, connID: []byte(nuid.Next()), pubNUID: nuid.New()}
+	c := conn{
+		clientID:        clientID,
+		opts:            DefaultOptions,
+		connID:          []byte(nuid.Next()),
+		pubNUID:         nuid.New(),
+		pubAckMap:       make(map[string]*ack),
+		pubAckCloseChan: make(chan struct{}),
+		subMap:          make(map[string]*subscription),
+	}
 	for _, opt := range options {
 		if err := opt(&c.opts); err != nil {
 			return nil, err
@@ -359,7 +373,8 @@ func Connect(stanClusterID, clientID string, options ...Option) (Conn, error) {
 	// Prepare a subscription on ping responses, even if we are not
 	// going to need it, so that if that fails, it fails before initiating
 	// a connection.
-	if c.pingSub, err = c.nc.Subscribe(nats.NewInbox(), c.processPingResponse); err != nil {
+	p := &c.ping
+	if p.sub, err = c.nc.Subscribe(nats.NewInbox(), c.processPingResponse); err != nil {
 		c.failConnect(err)
 		return nil, err
 	}
@@ -412,10 +427,6 @@ func Connect(stanClusterID, clientID string, options ...Option) (Conn, error) {
 		return nil, err
 	}
 	c.ackSubscription.SetPendingLimits(-1, -1)
-	c.pubAckMap = make(map[string]*ack)
-
-	// Create Subscription map
-	c.subMap = make(map[string]*subscription)
 
 	c.pubAckChan = make(chan struct{}, c.opts.MaxPubAcksInflight)
 
@@ -435,28 +446,28 @@ func Connect(stanClusterID, clientID string, options ...Option) (Conn, error) {
 			unsubPingSub = false
 
 			// These will be immutable.
-			c.pingRequests = cr.PingRequests
-			c.pingInbox = c.pingSub.Subject
+			p.requests = cr.PingRequests
+			p.inbox = p.sub.Subject
 			// In test, it is possible that we get a negative value
 			// to represent milliseconds.
 			if testAllowMillisecInPings && cr.PingInterval < 0 {
-				c.pingInterval = time.Duration(cr.PingInterval*-1) * time.Millisecond
+				p.interval = time.Duration(cr.PingInterval*-1) * time.Millisecond
 			} else {
 				// PingInterval is otherwise assumed to be in seconds.
-				c.pingInterval = time.Duration(cr.PingInterval) * time.Second
+				p.interval = time.Duration(cr.PingInterval) * time.Second
 			}
-			c.pingMaxOut = int(cr.PingMaxOut)
-			c.pingBytes, _ = (&pb.Ping{ConnID: c.connID}).Marshal()
+			p.maxOut = int(cr.PingMaxOut)
+			p.proto, _ = (&pb.Ping{ConnID: c.connID}).Marshal()
 			// Set the timer now that we are set. Use lock to create
 			// synchronization point.
-			c.pingMu.Lock()
-			c.pingTimer = time.AfterFunc(c.pingInterval, c.pingServer)
-			c.pingMu.Unlock()
+			p.mu.Lock()
+			p.timer = time.AfterFunc(p.interval, c.pingServer)
+			p.mu.Unlock()
 		}
 	}
 	if unsubPingSub {
-		c.pingSub.Unsubscribe()
-		c.pingSub = nil
+		p.sub.Unsubscribe()
+		p.sub = nil
 	}
 
 	return &c, nil
@@ -478,24 +489,24 @@ func (sc *conn) failConnect(err error) {
 // If the total number is > than the PingMaxOut option, then the connection
 // is closed, and connection error callback invoked if one was specified.
 func (sc *conn) pingServer() {
-	sc.pingMu.Lock()
+	p := &sc.ping
+	p.mu.Lock()
 	// In case the timer fired while we were stopping it.
-	if sc.pingTimer == nil {
-		sc.pingMu.Unlock()
+	if p.timer == nil {
+		p.mu.Unlock()
 		return
 	}
-	sc.pingOut++
-	if sc.pingOut > sc.pingMaxOut {
-		sc.pingMu.Unlock()
+	p.out++
+	if p.out > p.maxOut {
+		p.mu.Unlock()
 		sc.closeDueToPing(ErrMaxPings)
 		return
 	}
-	sc.pingTimer.Reset(sc.pingInterval)
-	nc := sc.nc
-	sc.pingMu.Unlock()
-	// Send the PING now. If the NATS connection is reported closed,
-	// we are done.
-	if err := nc.PublishRequest(sc.pingRequests, sc.pingInbox, sc.pingBytes); err == nats.ErrConnectionClosed {
+	p.timer.Reset(p.interval)
+	p.mu.Unlock()
+	// Send the PING now. If the NATS connection is reported closed, we are done.
+	// sc.nc is immutable and never nil, even if connection is closed.
+	if err := sc.nc.PublishRequest(p.requests, p.inbox, p.proto); err == nats.ErrConnectionClosed {
 		sc.closeDueToPing(err)
 	}
 }
@@ -521,16 +532,17 @@ func (sc *conn) processPingResponse(m *nats.Msg) {
 		}
 	}
 	// Do not attempt to decrement, simply reset to 0.
-	sc.pingMu.Lock()
-	sc.pingOut = 0
-	sc.pingMu.Unlock()
+	p := &sc.ping
+	p.mu.Lock()
+	p.out = 0
+	p.mu.Unlock()
 }
 
 // Closes a connection and invoke the connection error callback if one
 // was registered when the connection was created.
 func (sc *conn) closeDueToPing(err error) {
 	sc.Lock()
-	if sc.nc == nil {
+	if sc.closed {
 		sc.Unlock()
 		return
 	}
@@ -541,10 +553,8 @@ func (sc *conn) closeDueToPing(err error) {
 	if sc.ncOwned && !sc.nc.IsClosed() {
 		sc.nc.Close()
 	}
-	// Mark this streaming connection as closed. Do this under pingMu lock.
-	sc.pingMu.Lock()
-	sc.nc = nil
-	sc.pingMu.Unlock()
+	// Mark this streaming connection as closed.
+	sc.closed = true
 	// Capture callback (even though this is immutable).
 	cb := sc.connLostCB
 	sc.Unlock()
@@ -557,12 +567,13 @@ func (sc *conn) closeDueToPing(err error) {
 // Do some cleanup when connection is lost or closed.
 // Connection lock is held on entry, and sc.nc is guaranteed not to be nil.
 func (sc *conn) cleanupOnClose(err error) {
-	sc.pingMu.Lock()
-	if sc.pingTimer != nil {
-		sc.pingTimer.Stop()
-		sc.pingTimer = nil
+	p := &sc.ping
+	p.mu.Lock()
+	if p.timer != nil {
+		p.timer.Stop()
+		p.timer = nil
 	}
-	sc.pingMu.Unlock()
+	p.mu.Unlock()
 
 	// Unsubscribe only if the NATS connection is not already closed
 	// and we don't own it (otherwise connection is going to be closed
@@ -571,8 +582,8 @@ func (sc *conn) cleanupOnClose(err error) {
 		if sc.hbSubscription != nil {
 			sc.hbSubscription.Unsubscribe()
 		}
-		if sc.pingSub != nil {
-			sc.pingSub.Unsubscribe()
+		if p.sub != nil {
+			p.sub.Unsubscribe()
 		}
 		if sc.ackSubscription != nil {
 			sc.ackSubscription.Unsubscribe()
@@ -581,6 +592,7 @@ func (sc *conn) cleanupOnClose(err error) {
 
 	// Fail all pending pubs
 	for guid, pubAck := range sc.pubAckMap {
+		delete(sc.pubAckMap, guid)
 		if pubAck.t != nil {
 			pubAck.t.Stop()
 		}
@@ -589,11 +601,10 @@ func (sc *conn) cleanupOnClose(err error) {
 		} else if pubAck.ch != nil {
 			pubAck.ch <- err
 		}
-		delete(sc.pubAckMap, guid)
-		if len(sc.pubAckChan) > 0 {
-			<-sc.pubAckChan
-		}
 	}
+	// Prevent publish calls that have passed the connection close check but
+	// not yet send to pubAckChan to be possibly blocked.
+	close(sc.pubAckCloseChan)
 }
 
 // Close a connection to the stan system.
@@ -601,30 +612,24 @@ func (sc *conn) Close() error {
 	sc.Lock()
 	defer sc.Unlock()
 
-	if sc.nc == nil {
+	if sc.closed {
 		// We are already closed.
 		return nil
 	}
+	// Signals we are closed.
+	sc.closed = true
 
 	// Capture for NATS calls below.
-	nc := sc.nc
 	if sc.ncOwned {
-		defer nc.Close()
+		defer sc.nc.Close()
 	}
 
 	// Now close ourselves.
 	sc.cleanupOnClose(ErrConnectionClosed)
 
-	// Signals we are closed.
-	// Do this also under pingMu lock so that we don't need
-	// to grab sc's lock in pingServer.
-	sc.pingMu.Lock()
-	sc.nc = nil
-	sc.pingMu.Unlock()
-
 	req := &pb.CloseRequest{ClientID: sc.clientID}
 	b, _ := req.Marshal()
-	reply, err := nc.Request(sc.closeRequests, b, sc.opts.ConnectTimeout)
+	reply, err := sc.nc.Request(sc.closeRequests, b, sc.opts.ConnectTimeout)
 	if err != nil {
 		if err == nats.ErrTimeout {
 			return ErrCloseReqTimeout
@@ -648,6 +653,9 @@ func (sc *conn) Close() error {
 func (sc *conn) NatsConn() *nats.Conn {
 	sc.RLock()
 	nc := sc.nc
+	if sc.closed {
+		nc = nil
+	}
 	sc.RUnlock()
 	return nc
 }
@@ -655,12 +663,8 @@ func (sc *conn) NatsConn() *nats.Conn {
 // Process a heartbeat from the NATS Streaming cluster
 func (sc *conn) processHeartBeat(m *nats.Msg) {
 	// No payload assumed, just reply.
-	sc.RLock()
-	nc := sc.nc
-	sc.RUnlock()
-	if nc != nil {
-		nc.Publish(m.Reply, nil)
-	}
+	// sc.nc is immutable and never nil, even if connection is closed.
+	sc.nc.Publish(m.Reply, nil)
 }
 
 // Process an ack from the NATS Streaming cluster
@@ -710,7 +714,7 @@ func (sc *conn) PublishAsync(subject string, data []byte, ah AckHandler) (string
 func (sc *conn) publishAsync(subject string, data []byte, ah AckHandler, ch chan error) (string, error) {
 	a := &ack{ah: ah, ch: ch}
 	sc.Lock()
-	if sc.nc == nil {
+	if sc.closed {
 		sc.Unlock()
 		return "", ErrConnectionClosed
 	}
@@ -729,18 +733,28 @@ func (sc *conn) publishAsync(subject string, data []byte, ah AckHandler, ch chan
 	// snapshot
 	ackSubject := sc.ackSubject
 	ackTimeout := sc.opts.AckTimeout
-	pac := sc.pubAckChan
-	nc := sc.nc
 	sc.Unlock()
 
 	// Use the buffered channel to control the number of outstanding acks.
-	pac <- struct{}{}
+	select {
+	case sc.pubAckChan <- struct{}{}:
+	default:
+		// It seems faster to first try to send to pubAckChan and only if
+		// it fails to retry with the check on pubAckCloseChan than having
+		// simply only the select with the 2 cases.
+		select {
+		case sc.pubAckChan <- struct{}{}:
+		case <-sc.pubAckCloseChan:
+			return "", ErrConnectionClosed
+		}
+	}
 
-	err := nc.PublishRequest(subj, ackSubject, b)
+	// sc.nc is immutable and never nil once connection is created.
+	err := sc.nc.PublishRequest(subj, ackSubject, b)
 
 	// Setup the timer for expiration.
 	sc.Lock()
-	if err != nil || sc.nc == nil {
+	if err != nil || sc.closed {
 		sc.Unlock()
 		// If we got and error on publish or the connection has been closed,
 		// we need to return an error only if:
@@ -809,8 +823,7 @@ func (sc *conn) processMsg(raw *nats.Msg) {
 	var sub *subscription
 	// Lookup the subscription
 	sc.RLock()
-	nc := sc.nc
-	isClosed := nc == nil
+	isClosed := sc.closed
 	if !isClosed {
 		sub = sc.subMap[raw.Subject]
 	}
@@ -837,10 +850,11 @@ func (sc *conn) processMsg(raw *nats.Msg) {
 	}
 
 	// Process auto-ack
-	if !isManualAck && nc != nil {
+	if !isManualAck {
 		ack := &pb.Ack{Subject: msg.Subject, Sequence: msg.Sequence}
 		b, _ := ack.Marshal()
 		// FIXME(dlc) - Async error handler? Retry?
-		nc.Publish(ackSubject, b)
+		// sc.nc is immutable and never nil once connection is created.
+		sc.nc.Publish(ackSubject, b)
 	}
 }

--- a/stan_test.go
+++ b/stan_test.go
@@ -2207,9 +2207,9 @@ func TestPings(t *testing.T) {
 	// Check that connection is closed.
 	c := sc.(*conn)
 	c.RLock()
-	c.pingMu.Lock()
-	timerIsNil := c.pingTimer == nil
-	c.pingMu.Unlock()
+	c.ping.mu.Lock()
+	timerIsNil := c.ping.timer == nil
+	c.ping.mu.Unlock()
 	c.RUnlock()
 	if !timerIsNil {
 		t.Fatalf("Expected timer to be nil")


### PR DESCRIPTION
- Move all ping related fields into own pingInfo struct.
- Use connection closed boolean to check/set closed state instead
  of setting nc to nil. That makes sc.nc immutable and not nil
  and so code using that doesn't have to capture/check.
- Add a pubAckCloseChan that is closed during connection close
  to prevent publish call from being possibly blocked.

Regarding last point, we have tests and I tried to add a new one
but it would not catch the issue unless I would add a sleep in
publishAsync() after check of connection close and before sending
to pubAckChan.
The race is that if the connection is fully closed between these
two lines then if there are enough go routines trying to send to
the pubAckChan or MaxPubAcksInflight is low, the channel could be
full which would block the publishAsync() call.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>