### PR TITLE
Prepare for release v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ When using or transitioning to Go modules support:
 ```bash
 # Go client latest or explicit version
 go get github.com/nats-io/stan.go/@latest
-go get github.com/nats-io/stan.go/@v0.6.0
+go get github.com/nats-io/stan.go/@v0.7.0
 ```
 
 ## Basic Usage

--- a/stan.go
+++ b/stan.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Version is the NATS Streaming Go Client version
-const Version = "0.6.0"
+const Version = "0.7.0"
 
 const (
 	// DefaultNatsURL is the default URL the client connects to

--- a/stan_test.go
+++ b/stan_test.go
@@ -2615,7 +2615,7 @@ func TestNoMemoryLeak(t *testing.T) {
 		runtime.ReadMemStats(&newMem)
 		newInUse = newMem.HeapInuse
 
-		if newInUse-oldInUse <= 5*oneMB {
+		if newInUse < oldInUse || newInUse-oldInUse <= 5*oneMB {
 			return
 		}
 		time.Sleep(15 * time.Millisecond)


### PR DESCRIPTION
Almost no change compared to v0.6.0, but updated dependencies and
want to do a NATS Streaming server release, which then will reference
this new release.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>