### PR TITLE
[CHANGED] Default Ping settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 go:
+- 1.15.x
 - 1.14.x
 go_import_path: github.com/nats-io/stan.go
 install:
@@ -13,4 +14,4 @@ before_script:
 script:
 - go test -v -race . -modfile go_tests.mod
 after_success:
-- if [[ "$TRAVIS_GO_VERSION" =~ 1.14 ]]; then ./scripts/cov.sh TRAVIS; fi
+- if [[ "$TRAVIS_GO_VERSION" =~ 1.15 ]]; then ./scripts/cov.sh TRAVIS; fi

--- a/stan.go
+++ b/stan.go
@@ -43,7 +43,7 @@ const (
 	// DefaultPingInterval is the default interval (in seconds) at which a connection sends a PING to the server
 	DefaultPingInterval = 5
 	// DefaultPingMaxOut is the number of PINGs without a response before the connection is considered lost.
-	DefaultPingMaxOut = 3
+	DefaultPingMaxOut = 88
 )
 
 // Conn represents a connection to the NATS Streaming subsystem. It can Publish and


### PR DESCRIPTION
The current defaults were too small and would cause a client to
mark the connection as lost after 15 seconds or so. This means
that a server restart or leadership change may lead to the client
dropping the connection.

Made the change so that the overall time the client keeps the
connection valid is as long as the server default ping settings.

Of course, user that use Pings() option are not affected. This
is only changing the default values.
Also, in the event that the server no longer has the client, the
client will detect that at the first ping interval, which is
5 seconds (the interval has not changed).

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>