### PR TITLE
[FIXED] No panic on protobuf Unmarshal errors

### DIFF
--- a/pb/protocol.pb.go
+++ b/pb/protocol.pb.go
@@ -1377,7 +1377,7 @@ func (m *PubMsg) Unmarshal(dAtA []byte) error {
 			if skippy < 0 {
 				return ErrInvalidLengthProtocol
 			}
-			if (iNdEx + skippy) > l {
+			if (iNdEx+skippy) > l || (iNdEx+skippy) < 0 {
 				return io.ErrUnexpectedEOF
 			}
 			iNdEx += skippy
@@ -1485,7 +1485,7 @@ func (m *PubAck) Unmarshal(dAtA []byte) error {
 			if skippy < 0 {
 				return ErrInvalidLengthProtocol
 			}
-			if (iNdEx + skippy) > l {
+			if (iNdEx+skippy) > l || (iNdEx+skippy) < 0 {
 				return io.ErrUnexpectedEOF
 			}
 			iNdEx += skippy
@@ -1720,7 +1720,7 @@ func (m *MsgProto) Unmarshal(dAtA []byte) error {
 			if skippy < 0 {
 				return ErrInvalidLengthProtocol
 			}
-			if (iNdEx + skippy) > l {
+			if (iNdEx+skippy) > l || (iNdEx+skippy) < 0 {
 				return io.ErrUnexpectedEOF
 			}
 			iNdEx += skippy
@@ -1818,7 +1818,7 @@ func (m *Ack) Unmarshal(dAtA []byte) error {
 			if skippy < 0 {
 				return ErrInvalidLengthProtocol
 			}
-			if (iNdEx + skippy) > l {
+			if (iNdEx+skippy) > l || (iNdEx+skippy) < 0 {
 				return io.ErrUnexpectedEOF
 			}
 			iNdEx += skippy
@@ -2014,7 +2014,7 @@ func (m *ConnectRequest) Unmarshal(dAtA []byte) error {
 			if skippy < 0 {
 				return ErrInvalidLengthProtocol
 			}
-			if (iNdEx + skippy) > l {
+			if (iNdEx+skippy) > l || (iNdEx+skippy) < 0 {
 				return io.ErrUnexpectedEOF
 			}
 			iNdEx += skippy
@@ -2353,7 +2353,7 @@ func (m *ConnectResponse) Unmarshal(dAtA []byte) error {
 			if skippy < 0 {
 				return ErrInvalidLengthProtocol
 			}
-			if (iNdEx + skippy) > l {
+			if (iNdEx+skippy) > l || (iNdEx+skippy) < 0 {
 				return io.ErrUnexpectedEOF
 			}
 			iNdEx += skippy
@@ -2434,7 +2434,7 @@ func (m *Ping) Unmarshal(dAtA []byte) error {
 			if skippy < 0 {
 				return ErrInvalidLengthProtocol
 			}
-			if (iNdEx + skippy) > l {
+			if (iNdEx+skippy) > l || (iNdEx+skippy) < 0 {
 				return io.ErrUnexpectedEOF
 			}
 			iNdEx += skippy
@@ -2513,7 +2513,7 @@ func (m *PingResponse) Unmarshal(dAtA []byte) error {
 			if skippy < 0 {
 				return ErrInvalidLengthProtocol
 			}
-			if (iNdEx + skippy) > l {
+			if (iNdEx+skippy) > l || (iNdEx+skippy) < 0 {
 				return io.ErrUnexpectedEOF
 			}
 			iNdEx += skippy
@@ -2803,7 +2803,7 @@ func (m *SubscriptionRequest) Unmarshal(dAtA []byte) error {
 			if skippy < 0 {
 				return ErrInvalidLengthProtocol
 			}
-			if (iNdEx + skippy) > l {
+			if (iNdEx+skippy) > l || (iNdEx+skippy) < 0 {
 				return io.ErrUnexpectedEOF
 			}
 			iNdEx += skippy
@@ -3077,7 +3077,7 @@ func (m *UnsubscribeRequest) Unmarshal(dAtA []byte) error {
 			if skippy < 0 {
 				return ErrInvalidLengthProtocol
 			}
-			if (iNdEx + skippy) > l {
+			if (iNdEx+skippy) > l || (iNdEx+skippy) < 0 {
 				return io.ErrUnexpectedEOF
 			}
 			iNdEx += skippy
@@ -3156,7 +3156,7 @@ func (m *CloseRequest) Unmarshal(dAtA []byte) error {
 			if skippy < 0 {
 				return ErrInvalidLengthProtocol
 			}
-			if (iNdEx + skippy) > l {
+			if (iNdEx+skippy) > l || (iNdEx+skippy) < 0 {
 				return io.ErrUnexpectedEOF
 			}
 			iNdEx += skippy
@@ -3235,7 +3235,7 @@ func (m *CloseResponse) Unmarshal(dAtA []byte) error {
 			if skippy < 0 {
 				return ErrInvalidLengthProtocol
 			}
-			if (iNdEx + skippy) > l {
+			if (iNdEx+skippy) > l || (iNdEx+skippy) < 0 {
 				return io.ErrUnexpectedEOF
 			}
 			iNdEx += skippy

--- a/stan.go
+++ b/stan.go
@@ -700,7 +700,8 @@ func (sc *conn) processAck(m *nats.Msg) {
 	pa := &pb.PubAck{}
 	err := pa.Unmarshal(m.Data)
 	if err != nil {
-		panic(fmt.Errorf("error during ack unmarshal: %v", err))
+		fmt.Printf("error during ack unmarshal: %v\n", err)
+		return
 	}
 
 	// Remove
@@ -846,7 +847,8 @@ func (sc *conn) processMsg(raw *nats.Msg) {
 	msg := &Msg{}
 	err := msg.Unmarshal(raw.Data)
 	if err != nil {
-		panic(fmt.Errorf("error processing unmarshal for msg: %v", err))
+		fmt.Printf("error during message unmarshal: %v\n", err)
+		return
 	}
 	var sub *subscription
 	// Lookup the subscription


### PR DESCRIPTION
Fix the Unmarshal possible overflow and also do not make the library
panic on Unmarshal errors.
We don't have a proper way to return those errors since they happen
in callbacks. For now, just printing. May add a callback error later.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>