### PR TITLE
[FIXED] Prevent memory leak on subscription failure

### DIFF
--- a/stan_test.go
+++ b/stan_test.go
@@ -2815,6 +2815,10 @@ func TestSubTimeout(t *testing.T) {
 	if req.ClientID != clientName || req.Subject != "foo" || req.Inbox == "" {
 		t.Fatalf("Unexpected sub close request: %+v", req)
 	}
+
+	if len(scc.subMap) > 0 {
+		t.Fatal("Expected subMap to be empty")
+	}
 }
 
 func TestSubCloseError(t *testing.T) {

--- a/sub.go
+++ b/sub.go
@@ -262,6 +262,9 @@ func (sc *conn) subscribe(subject, qgroup string, cb MsgHandler, options ...Subs
 	// Listen for actual messages.
 	nsub, err := sc.nc.Subscribe(sub.inbox, sc.processMsg)
 	if err != nil {
+		sc.Lock()
+		delete(sc.subMap, sub.inbox)
+		sc.Unlock()
 		return nil, err
 	}
 	nsub.SetPendingLimits(-1, -1)
@@ -312,6 +315,9 @@ func (sc *conn) subscribe(subject, qgroup string, cb MsgHandler, options ...Subs
 			// Report this error to the user.
 			err = ErrSubReqTimeout
 		}
+		sc.Lock()
+		delete(sc.subMap, sub.inbox)
+		sc.Unlock()
 		return nil, err
 	}
 	r := &pb.SubscriptionResponse{}


### PR DESCRIPTION
 - modified subscribe fn to unregister sub from subMap when subscribe fails
 - mofiifed TestSubTimeout test

fixes #365 